### PR TITLE
Relax ActiveSupport dependency versioning.

### DIFF
--- a/instrumentable.gemspec
+++ b/instrumentable.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{Gem for decorating methods to use with ActiveSupport::Notifications}
   gem.homepage      = ""
 
-  gem.add_dependency 'activesupport', "~> 3.2"
+  gem.add_dependency 'activesupport', ">= 3.2"
   gem.add_development_dependency 'minitest'
 
   gem.files         = `git ls-files`.split($/)


### PR DESCRIPTION
Now that AS is in the 4.x version and above, I'm wondering if the instrumentable's dependency version can be relaxed to allow AS 4.x? I believe this will do it?

I'd be happy to bump the version etc... to gut a new gem if you're ok with this change.
